### PR TITLE
fix: Fix getContentUrlbyPath method when given path is '/Root'.

### DIFF
--- a/src/ODataApi.ts
+++ b/src/ODataApi.ts
@@ -64,7 +64,7 @@ export module ODataApi {
         ajax({ url: `${ROOT_URL()}${options.path}${ODataHelper.buildUrlParamString(options.params)}`, crossDomain: crossDomainParam(), method: 'GET' });
 
     export const CreateContent = (path: string, content: Content) => {
-        let contentItem = { __contentType: content.Type };
+        let contentItem = { __ContentType: content.Type };
         for (let prop in content) {
             if (prop !== 'Type') {
                 contentItem[prop] = content[prop];
@@ -100,12 +100,12 @@ export module ODataApi {
      * @returns {Observable} Returns an Rxjs observable that you can subscribe of in your code.
      */
     export const PatchContent = (id: number, fields: Object) => ajax({
-            url: `${ROOT_URL()}/content(${id})`,
-            method: 'PATCH',
-            responseType: 'json',
-            crossDomain: crossDomainParam(),
-            body: `models=[${JSON.stringify(fields)}]`
-        })
+        url: `${ROOT_URL()}/content(${id})`,
+        method: 'PATCH',
+        responseType: 'json',
+        crossDomain: crossDomainParam(),
+        body: `models=[${JSON.stringify(fields)}]`
+    })
     /**
      * Method to set multiple fields of a Content and clear the rest through OData REST API.
      * 
@@ -115,12 +115,12 @@ export module ODataApi {
      * @returns {Observable} Returns an Rxjs observable that you can subscribe of in your code.
      */
     export const PutContent = (id: number, fields: Object) => ajax({
-            url: `${ROOT_URL()}/content(${id})`,
-            method: 'PUT',
-            responseType: 'json',
-            crossDomain: crossDomainParam(),
-            body: `models=[${JSON.stringify(fields)}]`
-        })
+        url: `${ROOT_URL()}/content(${id})`,
+        method: 'PUT',
+        responseType: 'json',
+        crossDomain: crossDomainParam(),
+        body: `models=[${JSON.stringify(fields)}]`
+    })
     /**
      * Creates a wrapper function for a callable custom OData action.
      * 

--- a/src/ODataHelper.ts
+++ b/src/ODataHelper.ts
@@ -98,7 +98,7 @@ export module ODataHelper {
         let parentPath = path.substring(0, lastSlashPosition);
 
         let url;
-        if(name.indexOf('Root') > -1)
+        if (name.indexOf('Root') > -1)
             url = `${parentPath}/('${name}')`;
         else
             url = `${parentPath}('${name}')`

--- a/src/ODataHelper.ts
+++ b/src/ODataHelper.ts
@@ -97,7 +97,12 @@ export module ODataHelper {
         let name = path.substring(lastSlashPosition + 1);
         let parentPath = path.substring(0, lastSlashPosition);
 
-        return `${parentPath}('${name}')`;
+        let url;
+        if(name.indexOf('Root') > -1)
+            url = `${parentPath}/('${name}')`;
+        else
+            url = `${parentPath}('${name}')`
+        return url;
     }
     /**
      * Method that gets the URL that refers to a single item in the Sense/Net Content Repository by its Id


### PR DESCRIPTION
The getContentUrlbyPath method should insert a '/' before the entity name into the url when the
fiven path is only '/Root'.