### PR TITLE
[KFI]refactor(Content): renamed Actions() to GetActions(). Actions() …

### DIFF
--- a/src/Content/ContentInternal.ts
+++ b/src/Content/ContentInternal.ts
@@ -467,14 +467,20 @@
      * @param {string} scenario
      * @returns {Observable<ActionModel[]>} Returns an RxJS observable that you can subscribe of in your code.
      * ```
-     * content.Actions('ListItem')
+     * content.GetActions('ListItem')
      *   .subscribe(response => {
      *        console.log(response);
      *    },
      *    error: error => console.error('something wrong occurred: ' + error.responseJSON.error.message.value));
      * ```
      */
-    public Actions(scenario?: string): Observable<ActionModel[]> {
+     public Actions(scenario?: string): Observable<ActionModel[]> {
+         // tslint:disable-next-line:no-console
+         console.warn(`Method 'content.Action() is deprecated' and will be removed. Please use content.GetActions() instead`);
+         return this.GetActions(scenario);
+     }
+
+    public GetActions(scenario?: string): Observable<ActionModel[]> {
         return this._odata.Get({
             path: ODataHelper.joinPaths(this.GetFullPath(), 'Actions'),
             params: {

--- a/test/ContentTests.ts
+++ b/test/ContentTests.ts
@@ -591,22 +591,22 @@ export const contentTests = describe('Content', () => {
                     ]
                 }
             });
-            contentSaved.Actions().subscribe((actions) => {
+            contentSaved.GetActions().subscribe((actions) => {
                 expect(actions[0].Name).to.be.eq('Action1');
                 done();
             }, done);
-            expect(contentSaved.Actions()).to.be.instanceof(Observable);
+            expect(contentSaved.GetActions()).to.be.instanceof(Observable);
         });
 
     });
     describe('#Actions()', () => {
         it('should return an Observable object', () => {
-            expect(contentSaved.Actions()).to.be.instanceof(Observable);
+            expect(contentSaved.GetActions()).to.be.instanceof(Observable);
         });
     });
     describe('#Actions()', () => {
         it('should return an Observable object', () => {
-            expect(contentSaved.Actions('ListItem')).to.be.instanceof(Observable);
+            expect(contentSaved.GetActions('ListItem')).to.be.instanceof(Observable);
         });
     });
     describe('#GetAllowedChildTypes()', () => {


### PR DESCRIPTION
…marked as deprecated