### PR TITLE
[KFI]build(tsconfig): config review

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "compilerOptions": {
         "strict": true,
-        "removeComments": true,
-        "noImplicitAny": true,
         "noUnusedLocals": true,
         "target": "es2015",
         "module": "commonjs",
@@ -12,7 +10,6 @@
         "preserveConstEnums": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "skipLibCheck": true,
         "outDir": "./dist"
     },
     "exclude": [


### PR DESCRIPTION
removed *removeComments, *noImplicitAny* and *skipLibCheck* from tsconfig
 - **removeComments** Code comments will be used by IntelliSense when installed to another project. Recommendation: Comments should be trimmed during package bundling, if neccessary
 - **noImplicitAny** has been enabled by 'enableStrict' option (redundant option)
 - **skipLibCheck** was enabled temporarily because of an RxJs type error